### PR TITLE
🐛 fix: GitHub Actions 배포 스크립트 Docker 서비스명 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,10 +23,10 @@ jobs:
 
           # 브랜치별 환경 설정
           if [ "${{ github.event.pull_request.base.ref }}" = "main" ]; then
-            CONTAINER_NAME="coplan-prod"
+            CONTAINER_NAME="app-prod"
             echo "🚀 Deploying to PRODUCTION"
           elif [ "${{ github.event.pull_request.base.ref }}" = "develop" ]; then
-            CONTAINER_NAME="coplan-dev"
+            CONTAINER_NAME="app-dev"
             echo "🧪 Deploying to DEVELOPMENT"
           fi
 


### PR DESCRIPTION
## 📌 변경 사항 개요
Docker Compose 서비스명과 GitHub Actions 스크립트의 불일치 문제 수정

## ✨ 요약
배포 스크립트에서 사용하는 컨테이너 이름을 실제 docker-compose.yml의 서비스명과 일치하도록 수정했습니다.

## 📝 상세 내용
### 변경사항
- `CONTAINER_NAME="coplan-prod"` → `CONTAINER_NAME="app-prod"`
- `CONTAINER_NAME="coplan-dev"` → `CONTAINER_NAME="app-dev"`

### 원인
- docker-compose.yml: `app-prod`, `app-dev` 사용
- deploy.yml: `coplan-prod`, `coplan-dev` 사용
- 서비스명 불일치로 인한 배포 실패

## 🔗 관련 이슈
이전 PR #11에서 발생한 배포 오류 해결 

## 🖼️ 스크린샷
<img width="881" alt="image" src="https://github.com/user-attachments/assets/5d90ac81-b9d3-4c16-baf9-d6601b048b0f" />

## ✅ 체크리스트
- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
