### PR TITLE
🐛 fix: Docker 빌드 에러 해결 및 배포 스크립트 권한 문제 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 # 의존성 파일 복사
 COPY package*.json ./
 
-# 의존성 설치
-RUN npm ci --only=production
+# 모든 의존성 설치 (dev 포함)
+RUN npm ci
 
 # 소스 코드 복사
 COPY . .


### PR DESCRIPTION
## 📌 변경 사항 개요
Docker 빌드 시 발생하는 TypeScript 모듈 해석 에러 해결

## ✨ 요약
Docker 빌드 과정에서 개발 의존성을 포함하도록 수정하여 TypeScript 컴파일이 정상적으로 작동하도록 했습니다.

## 📝 상세 내용
### Dockerfile 수정
- `npm ci --only=production` → `npm ci`
- 빌드 시 필요한 TypeScript와 개발 도구들이 설치되도록 변경

### 문제 원인
- `Module not found: Can't resolve '@components/ThemeToggle'` 에러 발생
- production 모드에서 TypeScript가 설치되지 않아 경로 별칭(@components) 해석 불가
- 로컬에서는 정상 작동하나 Docker 빌드에서만 실패

## 🔗 관련 이슈
- PR #12 에서 발생한 Docker 빌드 에러 해결

## 🖼️ 스크린샷
<img width="710" alt="image" src="https://github.com/user-attachments/assets/f79e9b26-a34d-48ce-8b06-457bace95c30" />


## ✅ 체크리스트
- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- 권한 문제는 EC2에서 직접 해결 완료
- 추후 multi-stage build로 이미지 크기 최적화 가능