### PR TITLE
🐛 fix: Next.js 14 표준 standalone 배포 방식 적용

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  output: 'standalone',
+}
 
 export default nextConfig


### PR DESCRIPTION
## 📌 변경 사항 개요
Next.js 14 표준 배포 방식인 standalone 모드를 적용하여 메모리 사용량과 빌드 시간 문제 해결

## ✨ 요약
기존 일반 Node.js 배포 방식에서 Next.js 14 권장 standalone 방식으로 전환

## 📝 상세 내용
**next.config.mjs**
   - `output: 'standalone'` 설정 추가
   - Next.js가 최적화된 프로덕션 빌드 생성

**Dockerfile**
   - standalone 빌드 결과물만 포함
   - `npm start` → `node server.js` 직접 실행
   - 불필요한 node_modules 제거

## 🔗 관련 이슈
#16 

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- Next.js 14 공식 문서 권장 배포 방식 적용