### PR TITLE
✨Feat: 프로필 수정 컴포넌트 구현

### DIFF
--- a/src/app/features/auth/api/authApi.ts
+++ b/src/app/features/auth/api/authApi.ts
@@ -1,15 +1,21 @@
-import api from '@/app/shared/lib/axios'
+import authHttpClient from '@/app/shared/lib/axios'
 import { User as SignupResponse } from '@/app/shared/types/user.type'
 
 import { LoginRequest, LoginResponse, SignupRequest } from '../types/auth.type'
 import { AUTH_ENDPOINT } from './authEndpoint'
 
 export const login = async (data: LoginRequest): Promise<LoginResponse> => {
-  const response = await api.post<LoginResponse>(AUTH_ENDPOINT.LOGIN, data)
+  const response = await authHttpClient.post<LoginResponse>(
+    AUTH_ENDPOINT.LOGIN,
+    data,
+  )
   return response.data
 }
 
 export const signup = async (data: SignupRequest): Promise<SignupResponse> => {
-  const response = await api.post<SignupResponse>(AUTH_ENDPOINT.SIGNUP, data)
+  const response = await authHttpClient.post<SignupResponse>(
+    AUTH_ENDPOINT.SIGNUP,
+    data,
+  )
   return response.data
 }

--- a/src/app/features/auth/hooks/useLoginMutation.ts
+++ b/src/app/features/auth/hooks/useLoginMutation.ts
@@ -22,11 +22,11 @@ export function useLoginMutation() {
     },
     onError: (error) => {
       if (axios.isAxiosError(error)) {
-        const severMessage = (
+        const serverMessage = (
           error.response?.data as { message?: string } | undefined
         )?.message
         const fallback = error.message || '로그인 실패'
-        showError(severMessage ?? fallback)
+        showError(serverMessage ?? fallback)
       } else {
         showError('알 수 없는 에러 발생')
       }

--- a/src/app/features/auth/hooks/useSignupMutation.ts
+++ b/src/app/features/auth/hooks/useSignupMutation.ts
@@ -21,11 +21,11 @@ export function useSignupMutation() {
     },
     onError: (error) => {
       if (axios.isAxiosError(error)) {
-        const severMessage = (
+        const serverMessage = (
           error.response?.data as { message?: string } | undefined
         )?.message
         const fallback = error.message || '로그인 실패'
-        showError(severMessage ?? fallback)
+        showError(serverMessage ?? fallback)
       } else {
         showError('알 수 없는 에러 발생')
       }

--- a/src/app/features/mypage/api/mypageApi.ts
+++ b/src/app/features/mypage/api/mypageApi.ts
@@ -1,4 +1,4 @@
-import api from '@lib/axios'
+import authHttpClient from '@lib/axios'
 
 import { User as UserDataResponse } from '@/app/shared/types/user.type'
 
@@ -9,14 +9,17 @@ import {
 import { MYPAGE_ENDPOINT } from './mypageEndPoint'
 
 export async function loadUser(): Promise<UserDataResponse> {
-  const response = await api.get(MYPAGE_ENDPOINT.USER)
+  const response = await authHttpClient.get(MYPAGE_ENDPOINT.USER)
   return response.data
 }
 
 export async function updateMyProfile(
   data: UpdateProfileRequest,
 ): Promise<UserDataResponse> {
-  const response = await api.put<UserDataResponse>(MYPAGE_ENDPOINT.USER, data)
+  const response = await authHttpClient.put<UserDataResponse>(
+    MYPAGE_ENDPOINT.USER,
+    data,
+  )
   return response.data
 }
 
@@ -25,7 +28,7 @@ export async function uploadProfileImage(
 ): Promise<UploadProfileImageResponse> {
   const formData = new FormData()
   formData.append('image', image)
-  const response = await api.post<UploadProfileImageResponse>(
+  const response = await authHttpClient.post<UploadProfileImageResponse>(
     MYPAGE_ENDPOINT.IMAGE,
     formData,
   )

--- a/src/app/features/mypage/api/mypageApi.ts
+++ b/src/app/features/mypage/api/mypageApi.ts
@@ -2,7 +2,10 @@ import api from '@lib/axios'
 
 import { User as UserDataResponse } from '@/app/shared/types/user.type'
 
-import { UpdateProfileRequest } from '../types/mypage.type'
+import {
+  UpdateProfileRequest,
+  UploadProfileImageResponse,
+} from '../types/mypage.type'
 import { MYPAGE_ENDPOINT } from './mypageEndPoint'
 
 export async function loadUser(): Promise<UserDataResponse> {
@@ -13,6 +16,18 @@ export async function loadUser(): Promise<UserDataResponse> {
 export async function updateMyProfile(
   data: UpdateProfileRequest,
 ): Promise<UserDataResponse> {
-  const response = await api.post<UserDataResponse>(MYPAGE_ENDPOINT.USER, data)
+  const response = await api.put<UserDataResponse>(MYPAGE_ENDPOINT.USER, data)
+  return response.data
+}
+
+export async function uploadProfileImage(
+  image: File,
+): Promise<UploadProfileImageResponse> {
+  const formData = new FormData()
+  formData.append('image', image)
+  const response = await api.post<UploadProfileImageResponse>(
+    MYPAGE_ENDPOINT.IMAGE,
+    formData,
+  )
   return response.data
 }

--- a/src/app/features/mypage/api/mypageApi.ts
+++ b/src/app/features/mypage/api/mypageApi.ts
@@ -1,0 +1,18 @@
+import api from '@lib/axios'
+
+import { User as UserDataResponse } from '@/app/shared/types/user.type'
+
+import { UpdateProfileRequest } from '../types/mypage.type'
+import { MYPAGE_ENDPOINT } from './mypageEndPoint'
+
+export async function loadUser(): Promise<UserDataResponse> {
+  const response = await api.get(MYPAGE_ENDPOINT.USER)
+  return response.data
+}
+
+export async function updateMyProfile(
+  data: UpdateProfileRequest,
+): Promise<UserDataResponse> {
+  const response = await api.post<UserDataResponse>(MYPAGE_ENDPOINT.USER, data)
+  return response.data
+}

--- a/src/app/features/mypage/api/mypageEndPoint.ts
+++ b/src/app/features/mypage/api/mypageEndPoint.ts
@@ -1,3 +1,4 @@
 export const MYPAGE_ENDPOINT = {
   USER: `/${process.env.NEXT_PUBLIC_TEAM_ID}/users/me`,
+  IMAGE: `/${process.env.NEXT_PUBLIC_TEAM_ID}/users/me/image`,
 }

--- a/src/app/features/mypage/api/mypageEndPoint.ts
+++ b/src/app/features/mypage/api/mypageEndPoint.ts
@@ -1,0 +1,3 @@
+export const MYPAGE_ENDPOINT = {
+  USER: `/${process.env.NEXT_PUBLIC_TEAM_ID}/users/me`,
+}

--- a/src/app/features/mypage/components/ProfileEditForm.tsx
+++ b/src/app/features/mypage/components/ProfileEditForm.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+import Input from '@components/Input'
+import { showError, showSuccess } from '@lib/toast'
+import { isAxiosError } from 'axios'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { Controller, useForm } from 'react-hook-form'
+
+import { useUpdateMyProfileMutation } from '../hook/useUpdateMyProfileMutation'
+import { useUploadProfileImageMutation } from '../hook/useUploadProfileImageMutation'
+import { useUserQuery } from '../hook/useUserQurey'
+import { mypageValidation } from '../schemas/mypageValidation'
+import ProfileImageUpload from './ProfileImageUpload'
+
+interface ProfileFormData {
+  profileImageUrl: string | null
+  nickname: string
+  email: string
+}
+
+export default function ProfileEditForm() {
+  const { data: user } = useUserQuery() // get으로 사용자 데이터 최신화
+  const router = useRouter() // useClientQuery를 사용 하여 해당 부분에만 렌더링을 진행하려 했으나 다른 부분도 연동되는 부분이 있기 때문에 라우터 사용
+  const {
+    control,
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ProfileFormData>({
+    mode: 'onChange',
+    defaultValues: {
+      profileImageUrl: user?.profileImageUrl,
+      nickname: user?.nickname,
+      email: user?.email,
+    },
+  })
+
+  const [profileImageFile, setProfileImageFile] = useState<File | null>(null)
+  const { mutateAsync: uploadImage } = useUploadProfileImageMutation()
+  const { mutateAsync: updateProfile } = useUpdateMyProfileMutation()
+
+  // 유저 정보가 비동기적으로 넘어오기 때문에 유저가 로딩된 시점에서 RHF을 초기화 하기 위함 (SSR 도입 시 변경 예정)
+  useEffect(() => {
+    if (user) {
+      reset({
+        profileImageUrl: user.profileImageUrl ?? null,
+        nickname: user.nickname ?? '',
+        email: user.email ?? '',
+      })
+    }
+  }, [user, reset])
+
+  async function onSubmit(data: ProfileFormData) {
+    try {
+      // 현재 이미지 URL을 초기값으로 설정 (변경이 없을 수도 있기 때문)
+      let imageUrl = data.profileImageUrl
+
+      // 새 이미지를 업로드한 경우 → 서버에 업로드 요청 (POST)
+      if (profileImageFile) {
+        const { profileImageUrl } = await uploadImage(profileImageFile)
+        imageUrl = profileImageUrl
+      }
+
+      // 닉네임과 이미지 URL을 포함한 사용자 프로필 정보 생성
+      const submitData = {
+        nickname: data.nickname,
+        profileImageUrl: imageUrl,
+      }
+
+      // 서버에 프로필 정보 수정 요청 (PUT)
+      await updateProfile(submitData)
+
+      // 사용자에게 성공 알림 + 컴포넌트 최신화
+      showSuccess('프로필 변경이 완료되었습니다.')
+      router.refresh()
+    } catch (error) {
+      if (isAxiosError(error)) {
+        // 서버 에러 메시지 우선 처리, 없으면 기본 메시지
+        const severMessage = (
+          error.response?.data as { message?: string } | undefined
+        )?.message
+        const fallback = error.message || '프로필 변경에 실패하였습니다.'
+        showError(severMessage ?? fallback)
+      } else {
+        showError('알 수 없는 에러 발생')
+      }
+    }
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="BG-white flex h-auto w-full max-w-672 flex-col gap-24 rounded-8 p-24 font-medium"
+    >
+      <h2 className="text-2xl font-bold">프로필</h2>
+
+      <div className="flex justify-between gap-42 tablet:flex-col">
+        <Controller
+          name="profileImageUrl"
+          control={control}
+          render={({ field: { value, onChange } }) => (
+            <ProfileImageUpload
+              value={value} // 미리보기용 이미지 URL
+              onChange={onChange} // form 상태(profileImageUrl) 업데이트
+              onFileChange={(file) => setProfileImageFile(file)} // 서버 전송용 파일 저장
+            />
+          )}
+        />
+
+        <div className="flex flex-grow flex-col gap-16">
+          <Input labelName="이메일" {...register('email')} readOnly />
+          <Input
+            labelName="닉네임"
+            type="text"
+            placeholder="닉네임을 입력해 주세요"
+            autoComplete="off"
+            {...register('nickname', mypageValidation.nickname)}
+            hasError={!!errors.nickname}
+            errorMessage={errors.nickname?.message}
+          />
+          <button
+            type="submit"
+            className="BG-blue h-50 w-full rounded-8 text-white"
+          >
+            저장
+          </button>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/src/app/features/mypage/components/ProfileEditForm.tsx
+++ b/src/app/features/mypage/components/ProfileEditForm.tsx
@@ -78,11 +78,11 @@ export default function ProfileEditForm() {
     } catch (error) {
       if (isAxiosError(error)) {
         // 서버 에러 메시지 우선 처리, 없으면 기본 메시지
-        const severMessage = (
+        const serverMessage = (
           error.response?.data as { message?: string } | undefined
         )?.message
         const fallback = error.message || '프로필 변경에 실패하였습니다.'
-        showError(severMessage ?? fallback)
+        showError(serverMessage ?? fallback)
       } else {
         showError('알 수 없는 에러 발생')
       }

--- a/src/app/features/mypage/components/ProfileImageUpload.tsx
+++ b/src/app/features/mypage/components/ProfileImageUpload.tsx
@@ -43,7 +43,9 @@ export default function ProfileImageUpload({
 
   // 이미지 삭제 처리
   const handleDelete = () => {
-    if (preview) URL.revokeObjectURL(preview) // 메모리 누수 방지
+    if (preview && preview.startsWith('blob:')) {
+      URL.revokeObjectURL(preview) // 메모리 누수 방지
+    }
     setPreview(null)
     onChange(null) // RHF 상태 초기화
     if (inputRef.current) inputRef.current.value = ''

--- a/src/app/features/mypage/components/ProfileImageUpload.tsx
+++ b/src/app/features/mypage/components/ProfileImageUpload.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import CloseCircleIcon from '@components/common/CloseCircleIcon/CloseCircleIcon'
+import PlusIcon from '@components/common/PlusIcon/PlusIcon'
+import WhitePenIcon from '@components/common/WhitePenIcon/WhitePenIcon'
+import Image from 'next/image'
+import { useEffect, useRef, useState } from 'react'
+
+interface Props {
+  value: string | null // RHF에서 연결된 이미지 URL 상태 (미리보기용)
+  onChange: (url: string | null) => void // RHF 필드 상태 변경 함수
+  onFileChange?: (file: File) => void // 실제 업로드할 파일을 상위에서 처리할 수 있게 전달
+}
+
+export default function ProfileImageUpload({
+  value,
+  onChange,
+  onFileChange,
+}: Props) {
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const [preview, setPreview] = useState<string | null>(null)
+
+  // RHF나 상위 컴포넌트로부터 받은 value가 바뀌면 미리보기를 갱신
+  useEffect(() => {
+    setPreview(value)
+  }, [value])
+
+  // 파일이 선택되었을 때 처리
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    const url = URL.createObjectURL(file) // 로컬 미리보기 URL 생성
+    setPreview(url)
+    onChange(url) // RHF 상태 업데이트
+
+    // 서버 업로드용 파일을 상위로 전달
+    if (onFileChange) onFileChange(file)
+
+    // 같은 파일 다시 선택할 수 있도록 초기화
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  // 이미지 삭제 처리
+  const handleDelete = () => {
+    if (preview) URL.revokeObjectURL(preview) // 메모리 누수 방지
+    setPreview(null)
+    onChange(null) // RHF 상태 초기화
+    if (inputRef.current) inputRef.current.value = ''
+  }
+
+  return (
+    <div className="relative size-182 basis-182">
+      {/* 파일 선택 트리거 역할 */}
+      <label
+        htmlFor="userProfile"
+        className="BG-gray group relative flex size-full cursor-pointer items-center justify-center overflow-hidden rounded-lg"
+      >
+        {preview ? (
+          <>
+            {/* hover 시 연필 아이콘 */}
+            <div className="absolute inset-0 z-10 flex items-center justify-center bg-black/30 opacity-0 transition-opacity group-hover:opacity-100">
+              <WhitePenIcon size={30} />
+            </div>
+            {/* 이미지 미리보기 */}
+            <Image
+              src={preview}
+              alt="프로필 미리보기"
+              fill
+              className="z-0 object-cover"
+            />
+          </>
+        ) : (
+          // 아무 이미지도 없을 때 Plus 아이콘 표시
+          <PlusIcon className="Text-blue" />
+        )}
+      </label>
+
+      {/* 미리보기가 있을 때 삭제 버튼 표시 */}
+      {preview && (
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="absolute right-5 top-5 z-20 opacity-50 hover:opacity-100"
+        >
+          <CloseCircleIcon className="Text-gray" />
+        </button>
+      )}
+
+      <input
+        id="userProfile"
+        type="file"
+        accept="image/*"
+        className="hidden"
+        ref={inputRef}
+        onChange={handleChange}
+      />
+    </div>
+  )
+}

--- a/src/app/features/mypage/hook/useUpdateMyProfileMutation.ts
+++ b/src/app/features/mypage/hook/useUpdateMyProfileMutation.ts
@@ -1,0 +1,17 @@
+import { useMutation } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+import { User as UpdateProfileResponse } from '@/app/shared/types/user.type'
+
+import { updateMyProfile } from '../api/mypageApi'
+import { UpdateProfileRequest } from '../types/mypage.type'
+
+export function useUpdateMyProfileMutation() {
+  return useMutation<
+    UpdateProfileResponse,
+    AxiosError | Error,
+    UpdateProfileRequest
+  >({
+    mutationFn: updateMyProfile,
+  })
+}

--- a/src/app/features/mypage/hook/useUploadProfileImageMutation.ts
+++ b/src/app/features/mypage/hook/useUploadProfileImageMutation.ts
@@ -1,0 +1,11 @@
+import { useMutation } from '@tanstack/react-query'
+import { AxiosError } from 'axios'
+
+import { uploadProfileImage } from '../api/mypageApi'
+import { UploadProfileImageResponse } from '../types/mypage.type'
+
+export function useUploadProfileImageMutation() {
+  return useMutation<UploadProfileImageResponse, AxiosError | Error, File>({
+    mutationFn: uploadProfileImage,
+  })
+}

--- a/src/app/features/mypage/hook/useUserQurey.ts
+++ b/src/app/features/mypage/hook/useUserQurey.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { loadUser } from '../api/mypageApi'
+
+export function useUserQuery() {
+  return useQuery({
+    queryKey: ['loadUser'],
+    queryFn: loadUser,
+  })
+}

--- a/src/app/features/mypage/schemas/mypageValidation.ts
+++ b/src/app/features/mypage/schemas/mypageValidation.ts
@@ -1,0 +1,8 @@
+export const mypageValidation = {
+  nickname: {
+    pattern: {
+      value: /^[a-zA-Z가-힣]{1,10}$/,
+      message: '한글 또는 영어만 입력할 수 있으며, 최대 10자까지 가능합니다.',
+    },
+  },
+}

--- a/src/app/features/mypage/types/mypage.type.ts
+++ b/src/app/features/mypage/types/mypage.type.ts
@@ -1,4 +1,8 @@
 export interface UpdateProfileRequest {
   nickname: string
+  profileImageUrl: string | null
+}
+
+export interface UploadProfileImageResponse {
   profileImageUrl: string
 }

--- a/src/app/features/mypage/types/mypage.type.ts
+++ b/src/app/features/mypage/types/mypage.type.ts
@@ -1,0 +1,4 @@
+export interface UpdateProfileRequest {
+  nickname: string
+  profileImageUrl: string
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,3 +78,6 @@ body {
 .BG-drag-hovered {
   @apply bg-blue-100;
 }
+.Text-blue {
+  @apply text-[#83C8FA] dark:text-[#228DFF];
+}

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,12 +1,9 @@
 'use client'
 
-import Image from 'next/image'
-
 import Header from '@/app/shared/components/common/header/Header'
 import Sidebar from '@/app/shared/components/common/sidebar/Sidebar'
 
-import Input from '../shared/components/Input'
-
+import ProfileEditForm from '../features/mypage/components/ProfileEditForm'
 export default function Mypage() {
   return (
     <>
@@ -35,48 +32,14 @@ export default function Mypage() {
                   strokeLinejoin="round"
                 />
               </svg>
-              <button className="text-xm self-start">돌아가기</button>
+              <button type="button" className="text-xm self-start">
+                돌아가기
+              </button>
             </div>
             {/* 닉네임 프로필 변경 */}
-            <div className="BG-white flex h-auto w-full max-w-672 flex-col gap-24 rounded-8 p-24 font-medium">
-              <h2 className="text-2xl font-bold">테스트</h2>
-              <form className="flex justify-between gap-42 tablet:flex-col">
-                <div className="BG-gray relative flex size-182 basis-182 cursor-pointer items-center justify-center overflow-hidden rounded-lg">
-                  <svg
-                    width="24"
-                    height="24"
-                    viewBox="0 0 18 18"
-                    fill="none"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M9 3V15"
-                      stroke="#83C8FA"
-                      strokeWidth="3"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                    <path
-                      d="M3 9H15"
-                      stroke="#83C8FA"
-                      strokeWidth="3"
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                    />
-                  </svg>
-                </div>
-                <input className="hidden" type="file" />
-                <div className="flex flex-grow flex-col gap-16">
-                  <Input labelName="이메일" name="email" />
-                  <Input labelName="비밀번호" name="password" />
-                  <button className="w-pull BG-blue h-50 rounded-8 text-white">
-                    제출
-                  </button>
-                </div>
-              </form>
-            </div>
+            <ProfileEditForm />
             {/* 비밀번호 변경 */}
-            <div className="BG-white flex h-auto w-full max-w-672 flex-col gap-24 rounded-8 p-24">
+            {/* <div className="BG-white flex h-auto w-full max-w-672 flex-col gap-24 rounded-8 p-24">
               <h2 className="text-2xl font-bold">테스트</h2>
               <form className="flex flex-col justify-between gap-16">
                 <Input labelName="현재 비밀번호" name="password" />
@@ -86,7 +49,7 @@ export default function Mypage() {
                   변경
                 </button>
               </form>
-            </div>
+            </div> */}
           </div>
         </div>
       </div>

--- a/src/app/shared/components/Input.tsx
+++ b/src/app/shared/components/Input.tsx
@@ -45,6 +45,7 @@ const Input = forwardRef<HTMLInputElement, CustomInputProps>(
               className={cn(
                 'Text-black h-50 w-full rounded-8 px-16 py-12 text-base font-normal',
                 hasError ? 'Border-error' : 'Border-btn',
+                props.readOnly && 'Text-gray cursor-default',
               )}
               type={inputType}
               placeholder={placeholder}
@@ -72,6 +73,7 @@ const Input = forwardRef<HTMLInputElement, CustomInputProps>(
             className={cn(
               'Text-black h-50 w-full rounded-8 px-16 py-12 text-base font-normal',
               hasError ? 'Border-error' : 'Border-btn',
+              props.readOnly && 'Text-gray cursor-default',
             )}
             type={inputType}
             placeholder={placeholder}

--- a/src/app/shared/components/common/CloseCircleIcon/CloseCircleIcon.tsx
+++ b/src/app/shared/components/common/CloseCircleIcon/CloseCircleIcon.tsx
@@ -1,0 +1,40 @@
+interface CloseCircleIconProps extends React.SVGProps<SVGSVGElement> {
+  size?: number
+}
+
+export default function CloseCircleIcon({
+  size = 20,
+  ...props
+}: CloseCircleIconProps) {
+  return (
+    <>
+      <svg
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        fill="none"
+        {...props}
+      >
+        <circle cx="12" cy="12" r="12" fill="currentColor" />
+        <line
+          x1="8"
+          y1="8"
+          x2="16"
+          y2="16"
+          stroke="black"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+        <line
+          x1="16"
+          y1="8"
+          x2="8"
+          y2="16"
+          stroke="black"
+          strokeWidth="2"
+          strokeLinecap="round"
+        />
+      </svg>
+    </>
+  )
+}

--- a/src/app/shared/components/common/PlusIcon/PlusIcon.tsx
+++ b/src/app/shared/components/common/PlusIcon/PlusIcon.tsx
@@ -1,41 +1,38 @@
-interface PlusIconProps {
-  width?: number
-  height?: number
+interface PlusIconProps extends React.SVGProps<SVGSVGElement> {
+  size?: number
   weight?: number
-  className?: string
 }
 
 export default function PlusIcon({
-  width = 24,
-  height = 24,
+  size = 24,
   weight = 3,
-  className = 'Text-blue',
+  className,
+  ...props
 }: PlusIconProps) {
   return (
-    <>
-      <svg
-        className={className}
-        width={width}
-        height={height}
-        viewBox="0 0 18 18"
-        fill="none"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <path
-          d="M9 3V15"
-          stroke="currentColor"
-          strokeWidth={weight}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-        <path
-          d="M3 9H15"
-          stroke="currentColor"
-          strokeWidth={weight}
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        />
-      </svg>
-    </>
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M9 3V15"
+        stroke="currentColor"
+        strokeWidth={weight}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M3 9H15"
+        stroke="currentColor"
+        strokeWidth={weight}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   )
 }

--- a/src/app/shared/components/common/PlusIcon/PlusIcon.tsx
+++ b/src/app/shared/components/common/PlusIcon/PlusIcon.tsx
@@ -1,0 +1,41 @@
+interface PlusIconProps {
+  width?: number
+  height?: number
+  weight?: number
+  className?: string
+}
+
+export default function PlusIcon({
+  width = 24,
+  height = 24,
+  weight = 3,
+  className = 'Text-blue',
+}: PlusIconProps) {
+  return (
+    <>
+      <svg
+        className={className}
+        width={width}
+        height={height}
+        viewBox="0 0 18 18"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M9 3V15"
+          stroke="currentColor"
+          strokeWidth={weight}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M3 9H15"
+          stroke="currentColor"
+          strokeWidth={weight}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </svg>
+    </>
+  )
+}

--- a/src/app/shared/components/common/WhitePenIcon/WhitePenIcon.tsx
+++ b/src/app/shared/components/common/WhitePenIcon/WhitePenIcon.tsx
@@ -1,0 +1,20 @@
+interface WhitePenIconProps extends React.SVGProps<SVGSVGElement> {
+  size?: number
+}
+
+export default function WhitePenIcon({
+  size = 24,
+  ...props
+}: WhitePenIconProps) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" {...props}>
+      <path
+        d="M3 21L6.75 20.25L17.81 9.19C18.2 8.8 18.2 8.17 17.81 7.78L16.22 6.19C15.83 5.8 15.2 5.8 14.81 6.19L3.75 17.25L3 21Z"
+        stroke="white"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/src/app/shared/components/common/sidebar/modal/CreateDashboardModal.tsx
+++ b/src/app/shared/components/common/sidebar/modal/CreateDashboardModal.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image'
 import { useRouter } from 'next/navigation'
 import React, { useEffect, useState } from 'react'
 
-import api from '@/app/shared/lib/axios'
+import authHttpClient from '@/app/shared/lib/axios'
 import { useModalStore } from '@/app/shared/store/useModalStore'
 import { CreateDashboardRequest } from '@/app/shared/types/dashboard'
 
@@ -46,7 +46,10 @@ export default function CreateDashboardModal() {
         throw new Error('NEXT_PUBLIC_TEAM_ID 환경변수가 설정되지 않았습니다.')
       }
 
-      const response = await api.post(`/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards`, formData)
+      const response = await authHttpClient.post(
+        `/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards`,
+        formData,
+      )
 
       const data = response.data
 

--- a/src/app/shared/hooks/useDashboard.ts
+++ b/src/app/shared/hooks/useDashboard.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 
-import api from '../lib/axios'
+import authHttpClient from '../lib/axios'
 import { DashboardListResponse } from '../types/dashboard'
 
 export function useDashboard() {
@@ -21,7 +21,7 @@ export function useDashboard() {
         throw new Error('NEXT_PUBLIC_TEAM_ID 환경변수가 설정되지 않았습니다.')
       }
 
-      const response = await api.get<DashboardListResponse>(
+      const response = await authHttpClient.get<DashboardListResponse>(
         `/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards?navigationMethod=infiniteScroll`,
       )
       setDashboards(response.data.dashboards)

--- a/src/app/shared/lib/axios.ts
+++ b/src/app/shared/lib/axios.ts
@@ -1,6 +1,5 @@
 import axios from 'axios'
 
-import { AUTH_ENDPOINT } from '@/app/features/auth/api/authEndpoint'
 import { useAuthStore } from '@/app/features/auth/store/useAuthStore'
 
 const api = axios.create({
@@ -10,12 +9,10 @@ const api = axios.create({
 api.interceptors.request.use(
   (config) => {
     const token = useAuthStore.getState().accessToken
-    const publicPaths = [AUTH_ENDPOINT.LOGIN, AUTH_ENDPOINT.SIGNUP]
-    const isPulicPath = publicPaths.some((path) => config.url?.includes(path))
-
-    if (!isPulicPath && token) {
+    if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
+
     return config
   },
   (error) => {

--- a/src/app/shared/lib/axios.ts
+++ b/src/app/shared/lib/axios.ts
@@ -2,11 +2,11 @@ import axios from 'axios'
 
 import { useAuthStore } from '@/app/features/auth/store/useAuthStore'
 
-const api = axios.create({
+const authHttpClient = axios.create({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
 })
 
-api.interceptors.request.use(
+authHttpClient.interceptors.request.use(
   (config) => {
     const token = useAuthStore.getState().accessToken
     if (token) {
@@ -20,4 +20,4 @@ api.interceptors.request.use(
   },
 )
 
-export default api
+export default authHttpClient


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- 프로필 수정 컴포넌트 구현

## ✨ 요약

<!-- 구현 내용에 대한 간단한 설명 -->
 - 인스턴스 관련
   - axios 인스턴스 명 수정
   - 토큰 안 넘어오던 문제 수정
  
- 프로필 수정 컴포넌트 구현
  - 이미지 업로드 컴포넌트
  - 프로필 수정 폼
  - 프로필 수정 관련 API 작성
  - 프로필 수정 관련 쿼리 작성
 
 - 여러 SVG 아이콘 컴포넌트 추가 (Plus, pen, x 등)
 
## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- 내용이 어느 정도 있기 때문에 핵심 로직 부분에는 주석으로도 작성이 되어 있습니다.
- 시간이 그리 많지 않아 일부 누락 사항이 있을 수 있습니다.

### 인스턴스 관련
- 기존 인스턴스명 `api` 에서 `authHttpClient`로 변경되었습니다. (적용하고 있던 부분도 반영 완료)
- 일부 조건으로 인하여 토큰이 안 넘어가던 문제가 있어서 해당 조건문을 수정하였습니다. (예외처리로 사용한 부분은 리다이렉트 처리로 변경 예정)
```ts
// 변경 전
const publicPaths = [AUTH_ENDPOINT.LOGIN, AUTH_ENDPOINT.SIGNUP]
const isPulicPath = publicPaths.some((path) => config.url?.includes(path)) // 일부 url에서 false가 되버림

    if (!isPulicPath && token) {
      config.headers.Authorization = `Bearer ${token}`
    }

// 변경 
if (token) {
      config.headers.Authorization = `Bearer ${token}`
    }
```

### 컴포넌트 관련
- `SVG`로 작성한 컴포넌트가 추가 되었습니다. 적용과 관련된 부분은 해당 코드를 참고해주세요!
- `ProfileEditForm`, `ProfileImageUpload` 컴포넌트가 추가 되었습니다.


### ProfileEditForm
- `useUserQuery + reset` 를 통해 데이터를 최신화 (SSR 도입 시 변경될 수도 있습니다.)
- `reset`을 사용하여 유저가 로딩된 시점에서 해당 값을 초기화 하여 폼에 반영했습니다.

| 이름   | 주요 역할                                                       |
|--------|-----------------------------------------------------------------|
| reset  | 폼의 필드 값을 초기화하거나 외부 데이터로 재설정하며, 에러 등 상태도 초기화 |
```tsx


  // 유저 정보가 비동기적으로 넘어오기 때문에 유저가 로딩된 시점에서 RHF을 초기화 하기 위함 (SSR 도입 시 변경 예정)
  useEffect(() => {
    if (user) { // 유저의 정보가 넘어올 경우
      reset({ // react-hook-form 값 재설정
        profileImageUrl: user.profileImageUrl ?? null,
        nickname: user.nickname ?? '',
        email: user.email ?? '',
      })
    }
  }, [user, reset])
```
- 내부적으로 `ref` 사용하고 있어 `...register`로 제어가 어렵기 때문에 `Controller` 사용 

| 요소                                | 역할                                                                 |
|-------------------------------------|----------------------------------------------------------------------|
| `<Controller ... />`                | RHF의 커스텀 입력 컴포넌트 바인딩을 위한 래퍼 컴포넌트                          |
| `name="profileImageUrl"`            | RHF에서 관리할 필드의 이름 (form 상태 내 키 이름)                                 |
| `control={control}`                 | useForm 훅에서 생성한 control 객체로, RHF 내부 상태 제어에 필요                  |
| `render={({ field }) => ...}`       | RHF의 내부 상태와 연결되는 컴포넌트를 직접 그리는 방식                          |
| `field.value` → `value={value}`     | RHF가 현재 관리 중인 값 (이미지 URL)을 커스텀 컴포넌트에 전달 (미리보기용)      |
| `field.onChange` → `onChange={...}` | RHF의 상태를 업데이트하는 함수, 컴포넌트 내 변화 감지 시 호출됨                 |
| `onFileChange={(file) => ...}`      | RHF 외부 상태로 서버에 보낼 실제 파일(File)을 따로 저장                          |


```tsx 
<Controller
        name="profileImageUrl"
        control={control}
        render={({ field: { value, onChange } }) => (
          <ProfileImageUpload
            value={value} // 미리보기용 이미지 URL
            onChange={onChange} // form 상태(profileImageUrl) 업데이트
            onFileChange={(file) => setProfileImageFile(file)} // 서버 전송용 파일 저장
          />
        )}
      />
```
### ProfileImageUpload
- 프로필을 설정할 때 업로드 과정을 거쳐야 하기 때문에 상위 컴포넌트로 해당 URL을 넘겼습니다.
```tsx
// mypageApi.ts
export async function uploadProfileImage(
  image: File,
): Promise<UploadProfileImageResponse> {
  const formData = new FormData() // multipart/form-data 형식이 필요하기 때문에 사용
  formData.append('image', image) // image 라는 키로 해당 파일 추가
  const response = await authHttpClient.post<UploadProfileImageResponse>(
    MYPAGE_ENDPOINT.IMAGE,
    formData,
  )
  return response.data
}

// ProfileImageUpload.tsx 파일 변경 로직

  // 파일이 선택되었을 때 처리
  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
    const file = e.target.files?.[0]
    if (!file) return

    const url = URL.createObjectURL(file) // 로컬 미리보기 URL 생성
    setPreview(url)
    onChange(url) // RHF 상태 업데이트

    // 서버 업로드용 파일을 상위로 전달
    if (onFileChange) onFileChange(file)

    // 같은 파일 다시 선택할 수 있도록 초기화
    if (inputRef.current) inputRef.current.value = ''
  }

  // 이미지 삭제 처리
  const handleDelete = () => {
    if (preview) URL.revokeObjectURL(preview) // 메모리 누수 방지
    setPreview(null)
    onChange(null) // RHF 상태 초기화
    if (inputRef.current) inputRef.current.value = ''
  }
```
## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
#74 

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->


https://github.com/user-attachments/assets/1f00760e-288b-417b-aba3-eeb900f66299

### 호출 관련
- 제출 시 `/me`,`/image` API 호출 후 새로 고침
- `/me`가 많이 보이는 이유는 `GET` 요청의 `/me`와 `PUT` 요청의 `/me`가 존재합니다.

![image](https://github.com/user-attachments/assets/3dd1c901-e187-4705-82a9-a028f49a44c5)


## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- 마감 기한이 다가 오고 있기 때문에 일부 로직을 설명하지 못했습니다. (자세한 건 내부 코드를 확인해주세요!)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 마이페이지에서 프로필 이미지 업로드 및 미리보기, 닉네임/이메일 수정이 가능한 프로필 편집 폼이 추가되었습니다.
  - 프로필 이미지 업로드, 프로필 정보 수정, 유저 정보 조회를 위한 API 및 커스텀 훅이 도입되었습니다.
  - 닉네임 입력값에 대한 유효성 검사(한글/영문, 최대 10자)가 적용되었습니다.
  - 새로운 아이콘(플러스, 펜, 닫기)이 추가되었습니다.

- **버그 수정**
  - 로그인 및 회원가입 에러 처리에서 오타가 수정되어 서버 메시지가 올바르게 표시됩니다.

- **스타일**
  - 읽기 전용 입력창에 회색 텍스트와 기본 커서 스타일이 적용되었습니다.
  - 텍스트 색상을 지정하는 .Text-blue 클래스가 추가되었습니다.

- **리팩터**
  - 인증 및 대시보드 관련 API 요청에 사용하는 HTTP 클라이언트가 명확하게 분리 및 명명되었습니다.

- **기타**
  - 마이페이지의 기존 프로필/비밀번호 변경 UI가 새로운 프로필 편집 폼으로 대체되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->