### PR TITLE
Feat: 리다이렉트 처리

### DIFF
--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import Redirect from '@components/Redirect'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
 import { ReactNode, useState } from 'react'
@@ -14,7 +15,7 @@ export function Providers({ children }: { children: ReactNode }) {
         defaultTheme="system"
         enableSystem={true}
       >
-        {children}
+        <Redirect>{children}</Redirect>
       </ThemeProvider>
     </QueryClientProvider>
   )

--- a/src/app/shared/components/Redirect.tsx
+++ b/src/app/shared/components/Redirect.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useFirstDashboardIdQuery } from '@hooks/useFirstDashboardIdQuery'
+import { useMounted } from '@hooks/useMounted'
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect, useRef, useState } from 'react'
+
+import { useAuthStore } from '@/app/features/auth/store/useAuthStore'
+
+const PUBLIC_ROUTES = ['/login', '/signup']
+
+export default function Redirect({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const mounted = useMounted()
+  const { isLoggedIn } = useAuthStore()
+  const [redirecting, setRedirecting] = useState(false) // 중복 호출 방지
+  const prevPath = useRef(pathname) // 이전 경로 저장
+
+  const { data: firstDashboardId, isSuccess } = useFirstDashboardIdQuery()
+
+  // pathname 바뀌면 redirecting 초기화
+  useEffect(() => {
+    if (prevPath.current !== pathname) {
+      setRedirecting(false)
+      prevPath.current = pathname
+    }
+  }, [pathname])
+
+  useEffect(() => {
+    if (!mounted || redirecting) return
+
+    const isPublic = PUBLIC_ROUTES.includes(pathname)
+
+    // 🔒 비로그인 상태에서 private 경로 접근 시 → /login
+    if (!isLoggedIn && !isPublic && pathname !== '/') {
+      setRedirecting(true)
+      router.replace('/login')
+      return
+    }
+
+    // 🔐 로그인 상태에서 루트 접근 시 → /dashboard/{id}
+    if (isLoggedIn && pathname === '/') {
+      if (!isSuccess || !firstDashboardId) return
+      setRedirecting(true)
+      router.replace(`/dashboard/${firstDashboardId}`)
+      return
+    }
+
+    // 🔐 로그인 + 퍼블릭 경로 접근 시 → /mydashboard
+    if (isLoggedIn && isPublic) {
+      setRedirecting(true)
+      router.replace('/mydashboard')
+      return
+    }
+  }, [
+    pathname,
+    isLoggedIn,
+    mounted,
+    redirecting,
+    router,
+    isSuccess,
+    firstDashboardId,
+  ])
+
+  if (!mounted) return null
+  return <>{children}</>
+}

--- a/src/app/shared/components/Redirect.tsx
+++ b/src/app/shared/components/Redirect.tsx
@@ -30,7 +30,7 @@ export default function Redirect({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!mounted || redirecting) return // 마운트가 되지 않았거나 리다이렉션 중이 아니면 return
 
-    const isPublic = PUBLIC_ROUTES.includes(pathname)
+    const isPublic = PUBLIC_ROUTES.includes(pathname) //로그인 없이 접근 가능한 공개 라우트
 
     // 🔒 비로그인 상태에서 private 경로 접근 시 → /login
     if (!isLoggedIn && !isPublic && pathname !== '/') {

--- a/src/app/shared/components/Redirect.tsx
+++ b/src/app/shared/components/Redirect.tsx
@@ -41,9 +41,12 @@ export default function Redirect({ children }: { children: React.ReactNode }) {
 
     // 🔐 로그인 상태에서 루트 접근 시 → /dashboard/{id}
     if (isLoggedIn && pathname === '/') {
-      if (!isSuccess || !firstDashboardId) return
       setRedirecting(true)
-      router.replace(`/dashboard/${firstDashboardId}`)
+      if (isSuccess && firstDashboardId) {
+        router.replace(`/dashboard/${firstDashboardId}`)
+      } else if (isSuccess && !firstDashboardId) {
+        router.replace('/mydashboard')
+      }
       return
     }
 

--- a/src/app/shared/components/Redirect.tsx
+++ b/src/app/shared/components/Redirect.tsx
@@ -28,7 +28,7 @@ export default function Redirect({ children }: { children: React.ReactNode }) {
   }, [pathname])
 
   useEffect(() => {
-    if (!mounted || redirecting) return
+    if (!mounted || redirecting) return // 마운트가 되지 않았거나 리다이렉션 중이 아니면 return
 
     const isPublic = PUBLIC_ROUTES.includes(pathname)
 

--- a/src/app/shared/hooks/useFirstDashboardIdQuery.ts
+++ b/src/app/shared/hooks/useFirstDashboardIdQuery.ts
@@ -2,11 +2,13 @@ import { useQuery } from '@tanstack/react-query'
 
 import authHttpClient from '@/app/shared/lib/axios'
 
+import { DashboardListResponse } from '../types/dashboard'
+
 export function useFirstDashboardIdQuery() {
-  return useQuery({
+  return useQuery<DashboardListResponse, Error, string | number>({
     queryKey: ['firstDashboardId'],
     // 임시로 작성
-    queryFn: async () => {
+    queryFn: async (): Promise<DashboardListResponse> => {
       const response = await authHttpClient.get(
         `/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards`,
         {

--- a/src/app/shared/hooks/useFirstDashboardIdQuery.ts
+++ b/src/app/shared/hooks/useFirstDashboardIdQuery.ts
@@ -22,7 +22,7 @@ export function useFirstDashboardIdQuery() {
       return response.data
     },
     // 첫 번째 ID 값만 호출
-    select: (data) => data.dashboards?.[0].id ?? null,
+    select: (data) => data.dashboards?.[0]?.id ?? null,
     staleTime: 1000 * 60 * 5, // 5분 캐싱
   })
 }

--- a/src/app/shared/hooks/useFirstDashboardIdQuery.ts
+++ b/src/app/shared/hooks/useFirstDashboardIdQuery.ts
@@ -5,7 +5,7 @@ import authHttpClient from '@/app/shared/lib/axios'
 import { DashboardListResponse } from '../types/dashboard'
 
 export function useFirstDashboardIdQuery() {
-  return useQuery<DashboardListResponse, Error, string | number>({
+  return useQuery<DashboardListResponse, Error, number>({
     queryKey: ['firstDashboardId'],
     // 임시로 작성
     queryFn: async (): Promise<DashboardListResponse> => {

--- a/src/app/shared/hooks/useFirstDashboardIdQuery.ts
+++ b/src/app/shared/hooks/useFirstDashboardIdQuery.ts
@@ -7,7 +7,7 @@ import { DashboardListResponse } from '../types/dashboard'
 export function useFirstDashboardIdQuery() {
   return useQuery<DashboardListResponse, Error, number>({
     queryKey: ['firstDashboardId'],
-    // 임시로 작성
+    // 임시로 작성(대시보드 ID가 필요한데 해당 API 함수가 중복 될 가능성 고려)
     queryFn: async (): Promise<DashboardListResponse> => {
       const response = await authHttpClient.get(
         `/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards`,

--- a/src/app/shared/hooks/useFirstDashboardIdQuery.ts
+++ b/src/app/shared/hooks/useFirstDashboardIdQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+
+import authHttpClient from '@/app/shared/lib/axios'
+
+export function useFirstDashboardIdQuery() {
+  return useQuery({
+    queryKey: ['firstDashboardId'],
+    // 임시로 작성
+    queryFn: async () => {
+      const response = await authHttpClient.get(
+        `/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards`,
+        {
+          // 필수 값만 호출
+          params: {
+            navigationMethod: 'infiniteScroll',
+          },
+        },
+      )
+
+      return response.data
+    },
+    // 첫 번째 ID 값만 호출
+    select: (data) => data.dashboards?.[0].id ?? null,
+    staleTime: 1000 * 60 * 5, // 5분 캐싱
+  })
+}


### PR DESCRIPTION
## 📌 변경 사항 개요

<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->
- 리다이렉트 처리

## ✨ 요약

<!-- 구현 내용에 대한 간단한 설명 -->

## 📝 상세 내용

<!-- 구현 내용에 대한 자세한 설명 -->
- 쿠키도 고려 하였으나 고민 끝에 기존 코드를 해치지 않는 선으로 작업하게 되었습니다.
- `store`에 있는 `isLoggedIn`을 이용하여 리다이렉트 처리를 진행하였습니다.

### 로직 설명
```ts
  const router = useRouter()
  const pathname = usePathname()
  const mounted = useMounted() 
  const { isLoggedIn } = useAuthStore()
  const [redirecting, setRedirecting] = useState(false) // 중복 호출 방지
  const prevPath = useRef(pathname) // 이전 경로 저장
```
-  `isLoggedIn`으로 사용자의 로그인 여부를 체크
- `useRef`를 통하여 이전 경로를 가져옵니다.

```ts
useEffect(() => {
    if (prevPath.current !== pathname) {
      setRedirecting(false)
      prevPath.current = pathname
    }
  }, [pathname])
```
- ` router.replace`을 사용할 때 무한 루프를 방지하기 위해  `pathname`이 바뀌었을 때만 리다이렉트를 초기화 합니다.
```ts
  useEffect(() => {
    if (!mounted || redirecting) return // 마운트가 되지 않았거나 리다이렉션 중이 아니면 return

    const isPublic = PUBLIC_ROUTES.includes(pathname) //로그인 없이 접근 가능한 공개 라우트

    // 🔒 비로그인 상태에서 private 경로 접근 시 → /login
    if (!isLoggedIn && !isPublic && pathname !== '/') {
      setRedirecting(true)
      router.replace('/login')
      return
    }

    // 🔐 로그인 상태에서 루트 접근 시 → /dashboard/{id}
    if (isLoggedIn && pathname === '/') {
      if (!isSuccess || !firstDashboardId) return
      setRedirecting(true)
      router.replace(`/dashboard/${firstDashboardId}`)
      return
    }

    // 🔐 로그인 + 퍼블릭 경로 접근 시 → /mydashboard
    if (isLoggedIn && isPublic) {
      setRedirecting(true)
      router.replace('/mydashboard')
      return
    }
```
- 요구 사항에 맞게 분기 처리하여 작성하였습니다.
- `firstDashboardId` 같은 경우는 API 요청이 필요하기 때문에 임시 훅을 작성하였습니다.

```ts
export function useFirstDashboardIdQuery() {
  return useQueryy<DashboardListResponse, Error, string | number>({
    queryKey: ['firstDashboardId'],
    // 임시로 작성
    queryFn: async () => {
      const response = await authHttpClient.get(
        `/${process.env.NEXT_PUBLIC_TEAM_ID}/dashboards`,
        {
          // 필수 값만 호출
          params: {
            navigationMethod: 'infiniteScroll',
          },
        },
      )

      return response.data
    },
    // 첫 번째 ID 값만 호출
    select: (data) => data.dashboards?.[0].id ?? null,
    staleTime: 1000 * 60 * 5, // 5분 캐싱
  })
}
```
- `select`를 사용하여 ID 값만을 호출 하게 가공하였습니다.
- 중복 API 호출을 방지 하기 위해 `staleTime`을 사용하였습니다.

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->
 #32 

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->


https://github.com/user-attachments/assets/d700fc6b-6088-42dc-b683-f37e349f81ea




## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
- 머지가 되어 있지 않은 PR도 존재 하기 때문에 임시로 처리해두었습니다. (대시보드 ID가 필요한데 해당 API 함수가 중복 될 가능성 고려)
- 추가 작업이 있을 경우 리팩토링 할 때 반영하겠습니다.
- 미루고 미루다가 겨우 작성하게 되었네요..

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

- **신규 기능**
  - 사용자의 로그인 상태와 접근 경로에 따라 자동 리디렉션되는 기능이 추가되었습니다. 로그인하지 않은 사용자는 비공개 경로 접근 시 로그인 페이지로 이동하며, 로그인한 사용자는 루트 또는 공개 경로 접근 시 첫 번째 대시보드 또는 개인 대시보드로 자동 이동합니다.
- **기타**
  - 대시보드 목록에서 첫 번째 대시보드 ID를 가져오는 쿼리 기능이 추가되어 캐싱과 최적화가 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->