### PR TITLE
🐛 fix: React key 중복 및 401 인증 오류 해결

### DIFF
--- a/src/app/features/dashboard_Id/api/fetchCards.ts
+++ b/src/app/features/dashboard_Id/api/fetchCards.ts
@@ -1,6 +1,5 @@
-import api from '@/app/shared/lib/testAxios'
+import api from '@/app/shared/lib/axios'
 
-// import api from '@/app/shared/lib/axios'
 import { CardResponse } from '../type/Card.type'
 
 export async function fetchCards(

--- a/src/app/features/dashboard_Id/api/fetchCards.ts
+++ b/src/app/features/dashboard_Id/api/fetchCards.ts
@@ -1,4 +1,4 @@
-import api from '@/app/shared/lib/axios'
+import authHttpClient from '@/app/shared/lib/axios'
 
 import { CardResponse } from '../type/Card.type'
 
@@ -6,7 +6,7 @@ export async function fetchCards(
   columnId: number,
   size: number = 10,
 ): Promise<CardResponse> {
-  const res = await api.get<CardResponse>(
+  const res = await authHttpClient.get<CardResponse>(
     `/${process.env.NEXT_PUBLIC_TEAM_ID}/cards?size=${size}&columnId=${columnId}`,
   )
   return res.data

--- a/src/app/features/dashboard_Id/api/fetchColumns.ts
+++ b/src/app/features/dashboard_Id/api/fetchColumns.ts
@@ -1,6 +1,5 @@
-import api from '@/app/shared/lib/testAxios'
+import api from '@/app/shared/lib/axios'
 
-// import api from '@/app/shared/lib/axios'
 import { Column, ColumnsResponse } from '../type/Column.type'
 
 export async function fetchColumns(dashboardId: number): Promise<Column[]> {

--- a/src/app/features/dashboard_Id/api/fetchColumns.ts
+++ b/src/app/features/dashboard_Id/api/fetchColumns.ts
@@ -1,4 +1,4 @@
-import api from '@/app/shared/lib/axios'
+import authHttpClient from '@/app/shared/lib/axios'
 
 import { Column, ColumnsResponse } from '../type/Column.type'
 
@@ -7,7 +7,7 @@ export async function fetchColumns(dashboardId: number): Promise<Column[]> {
     throw new Error('dashboardId가 유효하지 않습니다.')
   }
 
-  const res = await api.get<ColumnsResponse>(
+  const res = await authHttpClient.get<ColumnsResponse>(
     `/${process.env.NEXT_PUBLIC_TEAM_ID}/columns?dashboardId=${dashboardId}`,
   )
 

--- a/src/app/mydashboard/components/MyDashboardGrid/MyDashboardGrid.tsx
+++ b/src/app/mydashboard/components/MyDashboardGrid/MyDashboardGrid.tsx
@@ -67,7 +67,10 @@ export default function MyDashboardGrid() {
 
         {/* 대시보드 카드 */}
         {dashboards.map((dashboard) => (
-          <MyDashboardCard key={dashboard.id} dashboard={dashboard} />
+          <MyDashboardCard
+            key={`mydash-${dashboard.id}`}
+            dashboard={dashboard}
+          />
         ))}
       </div>
 

--- a/src/app/shared/components/common/sidebar/Sidebar.tsx
+++ b/src/app/shared/components/common/sidebar/Sidebar.tsx
@@ -69,7 +69,7 @@ export default function Sidebar(): JSX.Element {
           ) : (
             dashboards.map((dashboard) => (
               <DashboardItem
-                key={dashboard.id}
+                key={`sidebar-${dashboard.id}`}
                 dashboard={dashboard}
                 isActive={pathname === `/dashboard/${dashboard.id}`}
                 onClick={() => handleDashboardClick(dashboard)}


### PR DESCRIPTION
## 📌 변경 사항 개요
React key 중복 경고와 401 인증 오류 해결

## ✨ 요약
- React key 중복으로 인한 경고 해결
- 401 인증 오류 해결

## 📝 상세 내용
### 1. React Key 중복 문제 해결
- **문제**: Sidebar와 MyDashboardGrid에서 동일한 `dashboard.id`를 key로 사용하여 충돌 발생
- **해결**: 각 컴포넌트별 고유 prefix 적용
    - Sidebar: `key={sidebar-${dashboard.id}}`
    - MyDashboardGrid: `key={mydash-${dashboard.id}}`

### 2. 401 인증 오류 해결
  - **문제**: fetchColumns, fetchCards에서 `testAxios` 사용으로 인증 -> 토큰 누락
  - **해결**: `authHttpClient`로 변경하여 자동 토큰 추가
    - `fetchColumns.ts`: testAxios → authHttpClient
    - `fetchCards.ts`: testAxios → authHttpClient


## 🔗 관련 이슈
<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷
<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트
- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Style**
  - 대시보드 카드와 사이드바 항목의 React key 값이 각각 "mydash-" 및 "sidebar-"로 id 앞에 접두사가 추가되어 일관된 key 형식으로 변경되었습니다.

- **Chores**
  - 내부 API 클라이언트 import가 테스트용 인스턴스에서 표준 인증 인스턴스로 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->