### PR TITLE
♻️refactor: 반응형 및 마무리 수정 작업

### DIFF
--- a/src/app/dashboard/[id]/edit/page.tsx
+++ b/src/app/dashboard/[id]/edit/page.tsx
@@ -23,14 +23,16 @@ export default function DashBoardEditPage() {
         <Image src="/images/back.png" alt="돌아가기" width={6} height={4} />
         <p className="text-14">돌아가기</p>
       </button>
-      <div className="flex w-500 flex-col gap-16 p-16">
+
+      {/* 컨텐츠 박스: 기본 너비 500px, 화면 작으면 100% 최대 500px */}
+      <div className="mx-auto ml-16 flex flex-col gap-16 p-16 sm:max-w-full sm:px-4">
         <EditInfo />
         <EditMember />
         <EditInvitation />
       </div>
 
-      {/* 삭제 버튼 영역 */}
-      <div className="BG-white align-center Text-btn i8 ml-16 flex w-292 justify-center rounded-md px-64 py-6">
+      {/* 삭제 버튼 영역: 기본 너비 292px, 화면 작으면 100% 최대 292px, 좌측 margin 제거 */}
+      <div className="BG-white align-center Text-btn i8 ml-16 mt-8 flex max-w-292 justify-center rounded-md px-16 py-6">
         <DeleteDashboardButton dashboardId={String(id)} />
       </div>
     </div>

--- a/src/app/features/auth/hooks/useAuth.ts
+++ b/src/app/features/auth/hooks/useAuth.ts
@@ -24,5 +24,6 @@ export function useAuth() {
   return {
     updateAuthState,
     logout,
+    setUser,
   }
 }

--- a/src/app/features/dashboard/components/edit/DeleteDashboardButton.tsx
+++ b/src/app/features/dashboard/components/edit/DeleteDashboardButton.tsx
@@ -58,7 +58,7 @@ export default function DeleteDashboardButton({
       onClick={handleDelete}
       // isLoading -> isPending으로 수정됨
       disabled={mutation.isPending}
-      className={`Text-black my-8 rounded-8 font-semibold transition-opacity ${
+      className={`Text-black my-8 whitespace-nowrap rounded-8 font-semibold transition-opacity ${
         mutation.isPending
           ? 'cursor-not-allowed opacity-50'
           : 'hover:opacity-90'

--- a/src/app/features/dashboard/components/edit/EditInfo.tsx
+++ b/src/app/features/dashboard/components/edit/EditInfo.tsx
@@ -16,7 +16,7 @@ export default function EditInfo() {
 
   return (
     <div>
-      <div className="BG-white h-300 w-584 rounded-16 px-32 py-24">
+      <div className="BG-white max-w-584 rounded-16 px-32 py-24">
         <h2 className="Text-black mb-24 text-18 font-bold">
           {selectedDashboard?.title || '대시보드 편집'}
         </h2>

--- a/src/app/features/dashboard/components/edit/EditInvitation.tsx
+++ b/src/app/features/dashboard/components/edit/EditInvitation.tsx
@@ -97,85 +97,77 @@ export default function EditInvitation() {
         : null
 
   return (
-    <div>
-      <div className="BG-white max-h-[360px] w-584 overflow-y-auto rounded-16 px-32 py-24">
-        <PaginationHeader
-          currentPage={currentPage}
-          totalPages={totalPages}
-          title="초대 내역"
-          onPrev={handlePrev}
-          onNext={handleNext}
+    <div className="BG-white w-full max-w-584 overflow-x-auto whitespace-nowrap rounded-16 px-32 py-24">
+      <PaginationHeader
+        currentPage={currentPage}
+        totalPages={totalPages}
+        title="초대 내역"
+        onPrev={handlePrev}
+        onNext={handleNext}
+      >
+        <button
+          onClick={() => openModal('invite')}
+          className="BG-violet flex w-fit shrink-0 items-center gap-8 rounded-5 px-12 py-6"
         >
-          <button
-            onClick={() => openModal('invite')}
-            className="BG-violet flex items-center gap-8 rounded-5 px-12 py-6"
-          >
-            <div className="relative flex size-12">
-              <Image src="/images/invitation-white.png" fill alt="초대 버튼" />
-            </div>
-            <p className="text-14 text-white">초대하기</p>
-          </button>
-        </PaginationHeader>
-
-        <form>
-          <label htmlFor="title" className="Text-black mb-8 block text-16">
-            이메일
-          </label>
-          <div className="flex flex-col gap-4">
-            {isLoading && (
-              <p className="Text-gray py-12 text-center">로딩 중...</p>
-            )}
-
-            {errorMessage && (
-              <p className="Text-blue py-12 text-center">{errorMessage}</p>
-            )}
-
-            {!isLoading && !errorMessage && currentItems.length === 0 && (
-              <p className="Text-gray py-12 text-center">
-                초대된 사용자가 없습니다.
-              </p>
-            )}
-
-            {!isLoading &&
-              !errorMessage &&
-              currentItems.map((member, index) => {
-                const isLast = index === currentItems.length - 1
-                return (
-                  <div
-                    key={member.id}
-                    className={cn(
-                      'flex items-center justify-between py-4',
-                      !isLast && 'Border-bottom',
-                    )}
-                  >
-                    <div className="flex items-center gap-12">
-                      <div className="flex flex-col">
-                        <Tooltip content={member.invitee.nickname}>
-                          <p className="Text-black cursor-help text-13">
-                            {member.invitee.email}
-                          </p>
-                        </Tooltip>
-                      </div>
-                    </div>
-
-                    <button
-                      type="button"
-                      disabled={cancelMutation.isPending}
-                      className={cn(
-                        'Text-btn Border-btn rounded-md px-16 py-2',
-                        cancelMutation.isPending &&
-                          'cursor-not-allowed opacity-50',
-                      )}
-                      onClick={() => cancelMutation.mutate(member.id)}
-                    >
-                      {cancelMutation.isPending ? '취소 중...' : '취소'}
-                    </button>
-                  </div>
-                )
-              })}
+          <div className="relative flex size-12 shrink-0">
+            <Image src="/images/invitation-white.png" fill alt="초대 버튼" />
           </div>
-        </form>
-      </div>
+          <p className="text-14 text-white">초대하기</p>
+        </button>
+      </PaginationHeader>
+
+      <form className="overflow-x-auto">
+        <label htmlFor="title" className="Text-black mb-8 block text-16">
+          이메일
+        </label>
+        <div className="flex flex-col gap-4">
+          {isLoading && (
+            <p className="Text-gray py-12 text-center">로딩 중...</p>
+          )}
+
+          {errorMessage && (
+            <p className="Text-blue py-12 text-center">{errorMessage}</p>
+          )}
+
+          {!isLoading &&
+            !errorMessage &&
+            currentItems.map((member, index) => {
+              const isLast = index === currentItems.length - 1
+              return (
+                <div
+                  key={member.id}
+                  className={cn(
+                    'flex items-center justify-between gap-12 py-4',
+                    !isLast && 'Border-bottom',
+                  )}
+                >
+                  <div className="flex min-w-0 items-center gap-12">
+                    <div className="flex min-w-0 flex-col">
+                      <Tooltip content={member.invitee.nickname}>
+                        <p className="Text-black max-w-[200px] cursor-help truncate text-13">
+                          {member.invitee.email}
+                        </p>
+                      </Tooltip>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    disabled={cancelMutation.isPending}
+                    className={cn(
+                      'Text-btn Border-btn w-fit shrink-0 rounded-md px-16 py-2',
+                      cancelMutation.isPending &&
+                        'cursor-not-allowed opacity-50',
+                    )}
+                    onClick={() => cancelMutation.mutate(member.id)}
+                  >
+                    {cancelMutation.isPending ? '취소 중...' : '취소'}
+                  </button>
+                </div>
+              )
+            })}
+        </div>
+      </form>
     </div>
   )
 }

--- a/src/app/features/dashboard/components/edit/EditMember.tsx
+++ b/src/app/features/dashboard/components/edit/EditMember.tsx
@@ -64,7 +64,7 @@ export default function EditMember() {
 
   return (
     <div>
-      <div className="BG-white h-360 w-584 rounded-16 px-32 py-24">
+      <div className="BG-white max-w-584 rounded-16 px-32 py-24">
         <PaginationHeader
           currentPage={currentPage}
           totalPages={totalPages}

--- a/src/app/features/dashboard/components/edit/PaginationHeader.tsx
+++ b/src/app/features/dashboard/components/edit/PaginationHeader.tsx
@@ -21,11 +21,11 @@ export function PaginationHeader({
   children,
 }: PaginationHeaderProps) {
   return (
-    <div className="mb-24 flex items-center justify-between">
+    <div className="mb-24 flex items-center justify-between whitespace-nowrap">
       <h2 className="Text-black text-18 font-bold">{title}</h2>
 
-      <div className="flex items-center">
-        <p className="Text-gray mr-16 text-12">
+      <div className="flex shrink-0 items-center">
+        <p className="Text-gray mr-16 shrink-0 text-12">
           {totalPages} 페이지 중 {currentPage}
         </p>
         <button onClick={onPrev} disabled={currentPage === 1}>

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -11,7 +11,10 @@ export default function Mypage() {
   const router = useRouter()
   return (
     <>
-      <Header />
+      <div className="pl-300">
+        <Header />
+      </div>
+
       <div className="BG-gray h-full">
         {/* 사이드바 */}
         <Sidebar />

--- a/src/app/shared/components/common/UserInfo.tsx
+++ b/src/app/shared/components/common/UserInfo.tsx
@@ -22,7 +22,9 @@ export function UserInfo({ nickname, imageUrl, size = 36 }: UserInfoProps) {
     <div className="flex items-center gap-4">
       {/* Avatar에 nickname, profileImageUrl 모두 넘겨줌 */}
       <Avatar size={size} name={displayNickname} imageUrl={displayImage} />
-      <span className="ml-4 text-sm font-semibold">{displayNickname}</span>
+      <span className="ml-4 text-sm font-semibold tablet:hidden">
+        {displayNickname}
+      </span>
     </div>
   )
 }

--- a/src/app/shared/components/common/header/Collaborator/CollaboratorList.tsx
+++ b/src/app/shared/components/common/header/Collaborator/CollaboratorList.tsx
@@ -31,7 +31,7 @@ export default function CollaboratorList() {
   const extraCount = members.length - MAX_COLLABS
 
   return (
-    <div className="flex gap-4">
+    <div className="flex -space-x-10">
       {visibleCollaborators.map((collab) => (
         <Tooltip key={collab.id} content={collab.nickname}>
           <div className="flex flex-col items-center text-xs">

--- a/src/app/shared/components/common/header/Header.tsx
+++ b/src/app/shared/components/common/header/Header.tsx
@@ -9,13 +9,15 @@ import UserDropdown from './UserDropdown'
 
 export default function Header() {
   return (
-    <header className="BG-white Border-bottom Text-black w-full overflow-x-hidden border-b px-48 py-10">
+    <header className="BG-white Border-bottom Text-black w-full overflow-x-auto border-b px-48 py-10">
       <div className="flex w-full items-center justify-between pr-16">
         {/* 좌측 대시보드명 */}
-        <LeftHeaderContent />
+        <div className="hidden lg:block">
+          <LeftHeaderContent />
+        </div>
 
         {/* 우측 사용자 정보/다크모드 */}
-        <div className="flex gap-16">
+        <div className="flex gap-16 whitespace-nowrap">
           <RightHeaderNav />
           <CreateInvitationModal />
           {/* 협업자 목록 */}

--- a/src/app/shared/components/common/header/LeftHeaderContent.tsx
+++ b/src/app/shared/components/common/header/LeftHeaderContent.tsx
@@ -1,19 +1,24 @@
 'use client'
 import Image from 'next/image'
+import { usePathname } from 'next/navigation'
 
 import { useSelectedDashboardStore } from '@/app/shared/store/useSelectedDashboardStore'
 
 export default function LeftHeaderContent() {
   const { selectedDashboard } = useSelectedDashboardStore()
+  const pathname = usePathname()
 
   if (!selectedDashboard) return null
 
   return (
     <div className="flex shrink-0 items-center gap-8 pr-16">
       <div className="whitespace-nowrap font-bold">
-        {selectedDashboard.title || '내 대시보드'}
+        {pathname === '/mypage'
+          ? '계정관리'
+          : selectedDashboard.title || '내 대시보드'}
       </div>
-      {selectedDashboard.createdByMe && (
+
+      {selectedDashboard.createdByMe && pathname !== '/mypage' && (
         <div className="relative h-12 w-14 overflow-hidden">
           <Image
             src="/images/crown.png"


### PR DESCRIPTION
## 📌 변경 사항 개요
반응형 및 마무리 수정 작업
<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## ✨ 요약
반응형 및 마무리 수정 작업
<!-- 구현 내용에 대한 간단한 설명 -->

## 📝 상세 내용
🐛fix: 
- 프로필 수정 후 저장 시 헤더 사용자 정보 미갱신 오류 수정
- 마이페이지의 헤더 왼쪽 컨텐츠 짤리는 문제 수정

🎨style: 
- 헤더 반응형 틀 작성
- 대시보드 수정 페이지 반응형 틀 작성
- 반응형 최대 너비 적용 및 글자 깨짐 방지
- 태블릿 사이즈에서 헤더의 사용자 닉네임 안 보이게 적용
- 마이페이지인 경우 계정관리가 보이도록 수정
- 공동 사용자 프로필 이미지 겹치도록 수정
<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷

https://github.com/user-attachments/assets/fd6b58ca-65d8-4ed1-979d-ecc531c97dae

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 마이페이지 경로에서 헤더 제목이 "계정관리"로 표시되고, 해당 경로에서는 크라운 아이콘이 숨겨집니다.
    - 사용자 프로필 수정 시 글로벌 사용자 상태가 자동으로 최신 정보로 갱신됩니다.
    - 인증 훅에서 setUser 함수를 직접 사용할 수 있습니다.

- **버그 수정**
    - 버튼 및 텍스트가 화면 크기에 따라 올바르게 정렬되고, 줄바꿈 및 오버플로우 이슈가 개선되었습니다.
    - 초대 및 멤버 관리, 대시보드 편집 화면의 레이아웃과 반응형 스타일이 개선되었습니다.

- **스타일**
    - 협업자 아바타가 서로 겹치도록 스타일이 변경되었습니다.
    - 헤더, 버튼, 사용자 정보 등 여러 컴포넌트의 레이아웃과 반응형 스타일이 개선되었습니다.
    - 닉네임이 태블릿 화면에서 숨겨지도록 조정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->