### PR TITLE
🎨 style: 대시보드 생성 모달, 컬럼 수정 모달 버튼 반응형

### DIFF
--- a/src/app/features/dashboard_Id/components/EditColumnModal.tsx
+++ b/src/app/features/dashboard_Id/components/EditColumnModal.tsx
@@ -158,7 +158,7 @@ export default function EditColumnModal() {
             <button
               type="button"
               onClick={handleDeleteClick}
-              className="BG-white Border-btn Text-gray h-54 w-256 rounded-8 px-16 py-10 text-16 font-medium"
+              className="BG-white Border-btn Text-gray mobile:h-54 mobile:w-144 h-54 w-256 rounded-8 px-16 py-10 text-16 font-medium"
             >
               삭제
             </button>
@@ -167,7 +167,7 @@ export default function EditColumnModal() {
             <button
               type="submit"
               disabled={isUpdateDisabled}
-              className={`BG-violet h-54 w-256 rounded-8 px-16 py-10 text-16 font-medium text-white transition-opacity ${
+              className={`BG-violet mobile:h-54 mobile:w-144 h-54 w-256 rounded-8 px-16 py-10 text-16 font-medium text-white transition-opacity ${
                 isUpdateDisabled
                   ? 'cursor-not-allowed opacity-50'
                   : 'hover:opacity-90'

--- a/src/app/shared/components/common/modal/CreateDashboardModal.tsx
+++ b/src/app/shared/components/common/modal/CreateDashboardModal.tsx
@@ -60,8 +60,10 @@ export default function CreateDashboardModal() {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
       onClick={handleBackdropClick}
     >
-      <div className="BG-white h-344 w-584 rounded-16 p-32">
-        <h2 className="Text-black mb-24 text-24 font-bold">새로운 대시보드</h2>
+      <div className="BG-white mobile:h-312 mobile:w-327 mobile:px-20 mobile:py-16 h-344 w-584 rounded-16 p-32">
+        <h2 className="Text-black mobile:text-20 mb-24 text-24 font-bold">
+          새로운 대시보드
+        </h2>
         <DashboardForm
           formData={formData}
           onChange={handleChange}

--- a/src/app/shared/components/dashboard/DashboardForm.tsx
+++ b/src/app/shared/components/dashboard/DashboardForm.tsx
@@ -33,7 +33,7 @@ export default function DashboardForm({
   return (
     <form onSubmit={onSubmit}>
       {/* 제목 */}
-      <div className="mb-24">
+      <div className="mb-24 text-16">
         <Input
           labelName="대시보드 이름"
           name="title"


### PR DESCRIPTION
## 📌 변경 사항 개요
- 대시보드 생성 모달 과 컬럼 수정 모달 반응형 적용
<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## ✨ 요약
- 대시보드 생성 모달 반응형 적용
- 컬럼 수정 모달 버튼 반응형 적용
<!-- 구현 내용에 대한 간단한 설명 -->

## 📝 상세 내용
- 모달크기: 데스크톱 584x344 -> 모바일 327x312
- 패딩 : 데스크톱 p-32 -> 모바일 px-20 py-16
- 제목 폰트 : 데스크톱 text-24 -> 모바일 text-20

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항
