### PR TITLE
♻️ refactor: Dockerfile에 빌드 시점 환경변수 설정 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,13 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+
+# 빌드 시점에 환경변수 설정 (외부에서 전달받음, 기본값 없음)
+ARG NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_TEAM_ID
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_TEAM_ID=$NEXT_PUBLIC_TEAM_ID
+
 RUN npm run build
 
 FROM base AS runner


### PR DESCRIPTION
## 📌 변경 사항 개요
 Dockerfile의 빌드 시점 환경변수 설정을 개선하여 외부에서 동적으로 환경변수를 전달받을 수 있도록 수정.
<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## ✨ 요약
- Dockerfile의 ARG/ENV 설정을 수정하여 빌드 시점에 외부에서 환경변수를 전달받을 수 있도록 개선
<!-- 구현 내용에 대한 간단한 설명 -->

## 📝 상세 내용
빌드 시점에 환경변수 설정 (외부에서 전달받음, 기본값 없음)
  ARG NEXT_PUBLIC_API_URL
  ARG NEXT_PUBLIC_TEAM_ID
<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Docker 빌드 시 외부에서 환경 변수(NEXT_PUBLIC_API_URL, NEXT_PUBLIC_TEAM_ID)를 지정할 수 있도록 지원합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->