### PR TITLE
♻️Refactor: 헤더 및 대시보드 수정 페이지 리팩토링

### DIFF
--- a/src/app/dashboard/[id]/edit/page.tsx
+++ b/src/app/dashboard/[id]/edit/page.tsx
@@ -31,8 +31,8 @@ export default function DashBoardEditPage() {
         <EditInvitation />
       </div>
 
-      {/* 삭제 버튼 영역: 기본 너비 292px, 화면 작으면 100% 최대 292px, 좌측 margin 제거 */}
-      <div className="BG-white align-center Text-btn i8 ml-16 mt-8 flex max-w-292 justify-center rounded-md px-16 py-6">
+      {/* 삭제 버튼 영역: 기본 너비 292px, 화면 작으면 100% 최대 292px */}
+      <div className="BG-white align-center Text-btn ml-48 mt-8 flex max-w-292 justify-center rounded-md px-16 py-6">
         <DeleteDashboardButton dashboardId={String(id)} />
       </div>
     </div>

--- a/src/app/dashboard/[id]/edit/page.tsx
+++ b/src/app/dashboard/[id]/edit/page.tsx
@@ -14,9 +14,10 @@ export default function DashBoardEditPage() {
   const router = useRouter()
 
   return (
-    <div className="BG-gray pb-16">
+    <div className="BG-gray px-4 pb-16 sm:px-8 md:px-16">
+      {/* 돌아가기 버튼 */}
       <button
-        className="flex cursor-pointer items-center gap-12 px-16 pt-16"
+        className="flex cursor-pointer items-center gap-12 pt-16"
         type="button"
         onClick={() => router.back()}
       >
@@ -24,15 +25,15 @@ export default function DashBoardEditPage() {
         <p className="text-14">돌아가기</p>
       </button>
 
-      {/* 컨텐츠 박스: 기본 너비 500px, 화면 작으면 100% 최대 500px */}
-      <div className="mx-auto ml-16 flex flex-col gap-16 p-16 sm:max-w-full sm:px-4">
+      {/* 콘텐츠 영역 */}
+      <div className="mobile-sm:max-w-full mt-8 flex w-full flex-col gap-16 pl-16 sm:max-w-[460px] md:max-w-[500px]">
         <EditInfo />
         <EditMember />
         <EditInvitation />
       </div>
 
-      {/* 삭제 버튼 영역: 기본 너비 292px, 화면 작으면 100% 최대 292px */}
-      <div className="BG-white align-center Text-btn ml-48 mt-8 flex max-w-292 justify-center rounded-md px-16 py-6">
+      {/* 삭제 버튼 영역 */}
+      <div className="BG-white Text-btn ml-18 mt-18 flex justify-center rounded-md py-6 sm:max-w-[292px]">
         <DeleteDashboardButton dashboardId={String(id)} />
       </div>
     </div>

--- a/src/app/dashboard/[id]/layout.tsx
+++ b/src/app/dashboard/[id]/layout.tsx
@@ -10,7 +10,7 @@ export default function AboutLayout({
   return (
     <>
       <Sidebar />
-      <div className="pl-300 tablet:pl-150 mobile-wide:pl-50">
+      <div className="pl-[300px] transition-all duration-300 mobile:pl-67 tablet:pl-[150px]">
         <Header />
         <main>{children}</main>
       </div>

--- a/src/app/dashboard/[id]/layout.tsx
+++ b/src/app/dashboard/[id]/layout.tsx
@@ -10,7 +10,7 @@ export default function AboutLayout({
   return (
     <>
       <Sidebar />
-      <div className="pl-300">
+      <div className="pl-300 tablet:pl-150 mobile-wide:pl-50">
         <Header />
         <main>{children}</main>
       </div>

--- a/src/app/features/dashboard/components/edit/DeleteDashboardButton.tsx
+++ b/src/app/features/dashboard/components/edit/DeleteDashboardButton.tsx
@@ -3,6 +3,7 @@
 import api from '@lib/axios'
 import { showError, showSuccess } from '@lib/toast'
 import { useMutation } from '@tanstack/react-query'
+import { useQueryClient } from '@tanstack/react-query'
 import axios from 'axios'
 import { useRouter } from 'next/navigation'
 import React from 'react'
@@ -16,6 +17,7 @@ export default function DeleteDashboardButton({
   dashboardId,
 }: DeleteDashboardButtonProps) {
   const router = useRouter()
+  const queryClient = useQueryClient()
 
   const mutation = useMutation<void, Error, void>({
     mutationFn: async () => {
@@ -27,7 +29,10 @@ export default function DeleteDashboardButton({
       )
     },
     onSuccess: () => {
-      router.push('/dashboard')
+      // 대시보드 삭제 후 사이드 바 대시보드 목록 쿼리 무효화
+      queryClient.invalidateQueries({ queryKey: ['dashboards'] })
+
+      router.push('/mydashboard')
       showSuccess('대시보드가 삭제되었습니다')
     },
     onError: (error) => {

--- a/src/app/features/dashboard/components/edit/EditInvitation.tsx
+++ b/src/app/features/dashboard/components/edit/EditInvitation.tsx
@@ -32,7 +32,6 @@ export default function EditInvitation() {
 
   const dashboardId = params.id as string
   const queryClient = useQueryClient()
-
   const [currentPage, setCurrentPage] = useState(1)
 
   const {
@@ -53,7 +52,6 @@ export default function EditInvitation() {
     retry: false,
   })
 
-  // length가 0인 경우에도 최소 페이지 1로 보장
   const totalPages = Math.max(
     1,
     Math.ceil(invitations.length / INVITATION_SIZE),
@@ -86,7 +84,6 @@ export default function EditInvitation() {
   const handlePrev = () => setCurrentPage((p) => Math.max(p - 1, 1))
   const handleNext = () => setCurrentPage((p) => Math.min(p + 1, totalPages))
 
-  // 에러 메시지 정리
   const errorMessage =
     isError && axios.isAxiosError(error)
       ? error.response?.status === 403
@@ -98,37 +95,55 @@ export default function EditInvitation() {
 
   return (
     <div className="BG-white w-full max-w-584 overflow-x-auto whitespace-nowrap rounded-16 px-32 py-24">
-      <PaginationHeader
-        currentPage={currentPage}
-        totalPages={totalPages}
-        title="초대 내역"
-        onPrev={handlePrev}
-        onNext={handleNext}
-      >
+      {/* Header + 초대 버튼 영역 (데스크탑용) */}
+      <div className="mb-16 flex flex-col gap-12 md:flex-row md:items-center md:justify-between">
+        <PaginationHeader
+          currentPage={currentPage}
+          totalPages={totalPages}
+          title="초대 내역"
+          onPrev={handlePrev}
+          onNext={handleNext}
+        />
+
+        {/* 데스크탑에서만 보이는 초대 버튼 */}
         <button
           onClick={() => openModal('invite')}
-          className="BG-violet flex w-fit shrink-0 items-center gap-8 rounded-5 px-12 py-6"
+          className="BG-violet mb-24 hidden w-fit shrink-0 items-center gap-8 self-end rounded-5 px-12 py-6 md:flex"
         >
           <div className="relative flex size-12 shrink-0">
             <Image src="/images/invitation-white.png" fill alt="초대 버튼" />
           </div>
           <p className="text-14 text-white">초대하기</p>
         </button>
-      </PaginationHeader>
+      </div>
 
+      {/* 이메일 입력 및 모바일 전용 버튼 */}
       <form className="overflow-x-auto">
-        <label htmlFor="title" className="Text-black mb-8 block text-16">
-          이메일
-        </label>
+        <div className="mb-8 flex flex-row items-center justify-between gap-4 md:block">
+          <label htmlFor="title" className="Text-black block text-16">
+            이메일
+          </label>
+
+          {/* 모바일/태블릿에서만 보이는 초대 버튼 */}
+          <button
+            onClick={() => openModal('invite')}
+            type="button"
+            className="BG-violet mb-12 flex w-fit shrink-0 items-center gap-8 rounded-5 px-12 py-6 md:hidden"
+          >
+            <div className="relative flex size-12 shrink-0">
+              <Image src="/images/invitation-white.png" fill alt="초대 버튼" />
+            </div>
+            <p className="text-14 text-white">초대하기</p>
+          </button>
+        </div>
+
         <div className="flex flex-col gap-4">
           {isLoading && (
             <p className="Text-gray py-12 text-center">로딩 중...</p>
           )}
-
           {errorMessage && (
             <p className="Text-blue py-12 text-center">{errorMessage}</p>
           )}
-
           {!isLoading &&
             !errorMessage &&
             currentItems.map((member, index) => {
@@ -150,7 +165,6 @@ export default function EditInvitation() {
                       </Tooltip>
                     </div>
                   </div>
-
                   <button
                     type="button"
                     disabled={cancelMutation.isPending}

--- a/src/app/features/dashboard/components/edit/EditMember.tsx
+++ b/src/app/features/dashboard/components/edit/EditMember.tsx
@@ -64,7 +64,7 @@ export default function EditMember() {
 
   return (
     <div>
-      <div className="BG-white max-w-584 rounded-16 px-32 py-24">
+      <div className="BG-white max-w-584 overflow-x-auto rounded-16 px-32 py-24">
         <PaginationHeader
           currentPage={currentPage}
           totalPages={totalPages}

--- a/src/app/features/dashboard/components/edit/EditMember.tsx
+++ b/src/app/features/dashboard/components/edit/EditMember.tsx
@@ -24,7 +24,7 @@ async function deleteMember(memberId: number): Promise<void> {
 export default function EditMember() {
   const queryClient = useQueryClient()
   const { id: dashboardId } = useParams()
-  const dashboardIdStr = String(dashboardId)
+  const dashboardIdNum = Number(dashboardId)
 
   const [currentPage, setCurrentPage] = useState(1)
 
@@ -33,9 +33,9 @@ export default function EditMember() {
     isLoading,
     isError,
   } = useQuery<Member[]>({
-    queryKey: ['members', dashboardIdStr],
-    queryFn: () => fetchMembers(dashboardIdStr),
-    enabled: !!dashboardIdStr,
+    queryKey: ['members', dashboardIdNum],
+    queryFn: () => fetchMembers(dashboardIdNum),
+    enabled: !!dashboardIdNum,
   })
 
   // 본인이 구성원으로 들어가기 때문에 0 페이지일 경우 X
@@ -55,7 +55,7 @@ export default function EditMember() {
     mutationFn: (memberId: number) => deleteMember(memberId),
     onSuccess: () => {
       showSuccess('삭제에 성공하였습니다.')
-      queryClient.invalidateQueries({ queryKey: ['members', dashboardIdStr] })
+      queryClient.invalidateQueries({ queryKey: ['members', dashboardIdNum] })
     },
     onError: () => {
       showError('삭제에 실패했습니다.')

--- a/src/app/features/dashboard/components/edit/PaginationHeader.tsx
+++ b/src/app/features/dashboard/components/edit/PaginationHeader.tsx
@@ -18,14 +18,13 @@ export function PaginationHeader({
   title,
   onPrev,
   onNext,
-  children,
 }: PaginationHeaderProps) {
   return (
-    <div className="mb-24 flex items-center justify-between whitespace-nowrap">
+    <div className="mb-20 flex max-w-500 items-center justify-between whitespace-nowrap">
       <h2 className="Text-black text-18 font-bold">{title}</h2>
 
       <div className="flex shrink-0 items-center">
-        <p className="Text-gray mr-16 shrink-0 text-12">
+        <p className="Text-gray mx-32 shrink-0 text-12">
           {totalPages} 페이지 중 {currentPage}
         </p>
         <button onClick={onPrev} disabled={currentPage === 1}>
@@ -52,7 +51,6 @@ export function PaginationHeader({
             height={36}
           />
         </button>
-        {children && <div className="ml-16">{children}</div>}
       </div>
     </div>
   )

--- a/src/app/shared/components/common/Dropdown/Dropdown.tsx
+++ b/src/app/shared/components/common/Dropdown/Dropdown.tsx
@@ -1,84 +1,78 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 
-// 드롭다운 컴포넌트 타입 정의
 type DropdownProps = {
-  trigger: React.ReactNode // 드롭다운을 열기 위한 트리거 요소 (버튼, 아이콘 등)
-  children: React.ReactNode // 드롭다운 내부 콘텐츠 (메뉴 아이템 등)
-  width?: string // Tailwind 클래스 기반의 너비 설정 (예: 'w-5', 'w-6')
-  align?: 'left' | 'center' | 'right' // 드롭다운 정렬 방향
-  className?: string // 사용자 정의 클래스
+  trigger: React.ReactNode
+  children: React.ReactNode
+  width?: string
+  align?: 'left' | 'center' | 'right'
+  className?: string
 }
 
-// 드롭다운 컴포넌트 정의
 export default function Dropdown({
   trigger,
   children,
-  width = 'w-6', // 기본 너비 설정
-  align = 'left', // 기본 정렬 방향 설정
+  width = 'w-6',
+  align = 'left',
+  className = '',
 }: DropdownProps) {
-  const [open, setOpen] = useState(false) // 드롭다운 열림 여부 상태
-  const triggerRef = useRef<HTMLDivElement>(null) // 반응형에 따른 위치 조정을 위한 ref 객체
-  const menuRef = useRef<HTMLDivElement>(null) // 외부 클릭 감지를 위한 드롭다운 메뉴 ref 객체
+  const [open, setOpen] = useState(false)
+  const triggerRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
   const [coords, setCoords] = useState<{ top: number; left: number }>({
     top: 0,
     left: 0,
-  }) // 드롭다운 메뉴 위치 좌표 상태
+  })
 
-  // 드롭다운 열기/닫기 토글
-  function toggleOpen() {
-    setOpen((prev) => !prev)
-  }
-
-  // Tailwind width 클래스 값을 실제 CSS 너비 값으로 변환
+  // Tailwind 너비를 px 값으로 변환
   function getWidthValue(width: string): string | undefined {
     switch (width) {
-      case 'w-5': // 할 일 카드 모달에서 사용
+      case 'w-5':
         return '5rem'
       case 'w-6':
         return '6rem'
       default:
-        return undefined // 정의되지 않은 값은 기본 width 적용
+        return undefined
     }
   }
 
-  // 드롭다운이 열릴 때 위치 계산 및 윈도우 이벤트 바인딩
-  useEffect(() => {
-    function updateCoords() {
-      if (open && triggerRef.current) {
-        const rect = triggerRef.current.getBoundingClientRect() // 트리거 위치 측정
+  // 위치 업데이트 함수 (useLayoutEffect로 변경)
+  useLayoutEffect(() => {
+    if (!open) return
 
+    function updateCoords() {
+      if (triggerRef.current) {
+        const rect = triggerRef.current.getBoundingClientRect()
         let left = rect.left
         if (align === 'center') left = rect.left + rect.width / 2
         else if (align === 'right') left = rect.right
 
         setCoords({
-          top: rect.bottom + window.scrollY, // 화면 스크롤 반영
+          top: rect.bottom,
           left,
         })
       }
     }
 
-    if (open) {
-      updateCoords()
-      window.addEventListener('resize', updateCoords)
-      window.addEventListener('scroll', updateCoords)
-    }
+    updateCoords()
+
+    window.addEventListener('scroll', updateCoords, { passive: true })
+    window.addEventListener('resize', updateCoords)
 
     return () => {
-      window.removeEventListener('resize', updateCoords)
       window.removeEventListener('scroll', updateCoords)
+      window.removeEventListener('resize', updateCoords)
     }
   }, [open, align])
 
-  // 드롭다운 외부 클릭 시 닫기
+  // 외부 클릭 감지해서 닫기
   useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
+    function handleClickOutside(e: MouseEvent) {
       if (
         menuRef.current &&
-        !menuRef.current.contains(event.target as Node) &&
+        !menuRef.current.contains(e.target as Node) &&
         triggerRef.current &&
-        !triggerRef.current.contains(event.target as Node)
+        !triggerRef.current.contains(e.target as Node)
       ) {
         setOpen(false)
       }
@@ -86,22 +80,18 @@ export default function Dropdown({
 
     if (open) {
       document.addEventListener('mousedown', handleClickOutside)
-    } else {
-      document.removeEventListener('mousedown', handleClickOutside)
     }
-
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [open])
 
-  // 드롭다운 메뉴 렌더링 (포탈을 이용하여 body로 위치)
   const menu = open
     ? createPortal(
         <div
           ref={menuRef}
           style={{
-            position: 'absolute',
+            position: 'fixed',
             top: coords.top,
             left: coords.left,
             transform:
@@ -112,24 +102,23 @@ export default function Dropdown({
                   : undefined,
             width: getWidthValue(width),
             minWidth: getWidthValue(width),
-            boxShadow: '0 2px 8px rgba(0,0,0,0.15)', // 그림자
-            borderRadius: 8, // 모서리 둥글게
-            zIndex: 9999, // 위로 띄우기
+            boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
+            borderRadius: 8,
+            zIndex: 9999,
           }}
-          className="BG-white" // 커스텀 배경 클래스 (Tailwind 예시)
+          className={`BG-white ${className}`}
         >
           {children}
         </div>,
-        document.body, // body에 포탈로 삽입
+        document.body,
       )
     : null
 
-  // 트리거 요소 + 드롭다운 메뉴 렌더링
   return (
     <>
       <div
         ref={triggerRef}
-        onClick={toggleOpen}
+        onClick={() => setOpen((prev) => !prev)}
         className="inline-block cursor-pointer"
       >
         {trigger}

--- a/src/app/shared/components/common/UserInfo.tsx
+++ b/src/app/shared/components/common/UserInfo.tsx
@@ -22,9 +22,7 @@ export function UserInfo({ nickname, imageUrl, size = 36 }: UserInfoProps) {
     <div className="flex items-center gap-4">
       {/* Avatar에 nickname, profileImageUrl 모두 넘겨줌 */}
       <Avatar size={size} name={displayNickname} imageUrl={displayImage} />
-      <span className="ml-4 text-sm font-semibold tablet:hidden">
-        {displayNickname}
-      </span>
+      <span className="ml-4 text-sm font-semibold">{displayNickname}</span>
     </div>
   )
 }

--- a/src/app/shared/components/common/header/Collaborator/CollaboratorList.tsx
+++ b/src/app/shared/components/common/header/Collaborator/CollaboratorList.tsx
@@ -12,16 +12,16 @@ const MAX_COLLABS = 4
 
 export default function CollaboratorList() {
   const { id: dashboardId } = useParams()
-  const dashboardIdStr = String(dashboardId)
+  const dashboardIdNum = Number(dashboardId)
 
   const {
     data: members = [],
     isLoading,
     isError,
   } = useQuery<Member[]>({
-    queryKey: ['members', dashboardIdStr],
-    queryFn: () => fetchMembers(dashboardIdStr),
-    enabled: !!dashboardIdStr,
+    queryKey: ['members', dashboardIdNum],
+    queryFn: () => fetchMembers(dashboardIdNum),
+    enabled: !!dashboardIdNum,
   })
 
   if (isLoading && isError) return null

--- a/src/app/shared/components/common/header/LeftHeaderContent.tsx
+++ b/src/app/shared/components/common/header/LeftHeaderContent.tsx
@@ -8,17 +8,22 @@ export default function LeftHeaderContent() {
   const { selectedDashboard } = useSelectedDashboardStore()
   const pathname = usePathname()
 
-  if (!selectedDashboard) return null
+  const isMypage = pathname === '/mypage'
+  const isMyDashboard = pathname === '/mydashboard'
+  const showCrown =
+    selectedDashboard?.createdByMe && !isMypage && !isMyDashboard
+
+  const title = isMypage
+    ? '계정관리'
+    : isMyDashboard
+      ? '내 대시보드'
+      : selectedDashboard?.title || '내 대시보드'
 
   return (
     <div className="flex shrink-0 items-center gap-8 pr-16">
-      <div className="whitespace-nowrap font-bold">
-        {pathname === '/mypage'
-          ? '계정관리'
-          : selectedDashboard.title || '내 대시보드'}
-      </div>
+      <div className="whitespace-nowrap font-bold">{title}</div>
 
-      {selectedDashboard.createdByMe && pathname !== '/mypage' && (
+      {showCrown && (
         <div className="relative h-12 w-14 overflow-hidden">
           <Image
             src="/images/crown.png"

--- a/src/app/shared/components/common/header/RightHeaderNav.tsx
+++ b/src/app/shared/components/common/header/RightHeaderNav.tsx
@@ -2,27 +2,35 @@
 
 import { useModalStore } from '@store/useModalStore'
 import { useSelectedDashboardStore } from '@store/useSelectedDashboardStore'
+import { usePathname } from 'next/navigation'
 
 import NavItem from './NavItem'
 
 export default function RightHeaderNav() {
   const { openModal } = useModalStore()
   const { selectedDashboard } = useSelectedDashboardStore()
+  const pathname = usePathname()
+
+  const isMyDashboardPage = pathname === '/mydashboard'
 
   return (
     <nav className="Text-black hidden gap-6 whitespace-nowrap text-sm md:flex">
-      <NavItem
-        as="link"
-        href={`/dashboard/${selectedDashboard?.id}/edit`}
-        iconSrc="/images/config.svg"
-        label="관리"
-      />
-      <NavItem
-        as="button"
-        onClick={() => openModal('invite')}
-        iconSrc="/images/invitation.png"
-        label="초대하기"
-      />
+      {!isMyDashboardPage && (
+        <>
+          <NavItem
+            as="link"
+            href={`/dashboard/${selectedDashboard?.id}/edit`}
+            iconSrc="/images/config.svg"
+            label="관리"
+          />
+          <NavItem
+            as="button"
+            onClick={() => openModal('invite')}
+            iconSrc="/images/invitation.png"
+            label="초대하기"
+          />
+        </>
+      )}
     </nav>
   )
 }

--- a/src/app/shared/hooks/useMembers.ts
+++ b/src/app/shared/hooks/useMembers.ts
@@ -14,7 +14,7 @@ export type Member = {
 
 const teamId = getTeamId()
 
-export async function fetchMembers(dashboardId: string): Promise<Member[]> {
+export async function fetchMembers(dashboardId: number): Promise<Member[]> {
   const { data } = await authHttpClient.get(`/${teamId}/members`, {
     params: {
       page: 1,

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
       screens: {
         mobile: { max: '375px' }, // 0 ~ 375px
         tablet: { raw: '(min-width: 376px) and (max-width: 744px)' }, // 376 ~ 1919px
+        'mobile-sm': { max: '500px' }, // ✅ 0 ~ 500px
         'mobile-wide': { raw: '(min-width: 0px) and (max-width: 683px)' }, // 0 ~ 683px
         'tablet-wide': { raw: '(min-width: 684px) and (max-width: 1439px)' }, // 684 ~ 1439px
       },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -19,7 +19,7 @@ const config: Config = {
       screens: {
         mobile: { max: '375px' }, // 0 ~ 375px
         tablet: { raw: '(min-width: 376px) and (max-width: 744px)' }, // 376 ~ 1919px
-        'mobile-sm': { max: '500px' }, // ✅ 0 ~ 500px
+        'mobile-sm': { max: '500px' }, // 0 ~ 500px
         'mobile-wide': { raw: '(min-width: 0px) and (max-width: 683px)' }, // 0 ~ 683px
         'tablet-wide': { raw: '(min-width: 684px) and (max-width: 1439px)' }, // 684 ~ 1439px
       },


### PR DESCRIPTION
## 📌 변경 사항 개요
헤더 및 대시보드 수정 페이지 리팩토링
<!-- 이 PR에서 수행한 변경 사항에 대한 간략한 설명 -->

## ✨ 요약
헤더 및 대시보드 수정 페이지 리팩토링
<!-- 구현 내용에 대한 간단한 설명 -->

## 📝 상세 내용
♻️ refactor:
- 대시보드 삭제 후 mydashboard로 이동 및 삭제 후 사이드 바 쿼리 갱신하여 삭제 반영
- 대시보드 수정 페이지 헤더 반응형 수정
- 경로가 mydashboard인 경우 관리 및 초대하기 버튼 미표시
- 드롭다운 위치 뷰포트 기준 위치 적용을 위한 position 수정

🎨style: 
- 초대하기 버튼 반응형에 따른 위치 변경 적용
- 페이지네이션 컴포넌트 반응형에 따른 스타일 수정
- 반응형에 따른 사용자 정보 스타일 수정
- 헤더 왼쪽 제목 부분 내 대시보드 경로인 경우를 위한 스타일 수정
- dashboardId 타입 number형으로 변환 및 그에 따른 수정
- mobile-sm 사이즈 추가
- 대시보드 수정 페이지 반응형 적용
- 구성원 수정 컴포넌트 페이지네이션 버튼 사라지도록 스타일 수정

🫧 modify: 대시보드 삭제 버튼 위치 조정
<!-- 구현 내용에 대한 자세한 설명 -->

## 🔗 관련 이슈

<!-- 관련된 이슈 번호 (예: Resolves: #123) -->

## 🖼️ 스크린샷

<!-- UI 변경이 있는 경우 변경 전/후 스크린샷 -->

## ✅ 체크리스트

- [x] 브랜치 네이밍 컨벤션을 준수했습니다
- [x] 커밋 컨벤션을 준수했습니다
- [x] 코드가 프로젝트의 스타일 가이드라인을 준수합니다

## 💡 참고 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - 대시보드 편집 페이지에 "뒤로가기" 버튼과 반응형 레이아웃이 추가되었습니다.
  - Tailwind에 500px 이하를 위한 'mobile-sm' 반응형 브레이크포인트가 추가되었습니다.

- **버그 수정**
  - 드롭다운 메뉴의 위치와 동작이 더욱 안정적으로 개선되었습니다.
  - 대시보드 삭제 시 사이드바 목록이 자동 갱신되며, 삭제 후 이동 경로가 변경되었습니다.

- **스타일/레이아웃**
  - 여러 컴포넌트의 레이아웃과 여백이 반응형으로 개선되어 모바일, 태블릿, 데스크톱에서 더 깔끔하게 표시됩니다.
  - 사용자 닉네임이 모든 화면 크기에서 항상 표시됩니다.
  - 초대 및 멤버 관리 UI가 모바일 환경에서 더 편리하게 동작합니다.

- **리팩터**
  - 일부 내부 데이터 타입이 문자열에서 숫자로 변경되어 데이터 일관성이 향상되었습니다.
  - 헤더 내 네비게이션 및 타이틀 표시 조건이 명확하게 정리되었습니다.

- **문서화**
  - 해당 변경에 따른 공개 함수 시그니처가 일부 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->